### PR TITLE
#12 + #20: Adjust displaying of Loot Info frame

### DIFF
--- a/Source/Modules/delves_dash_extention/delves_dash_extention.xml
+++ b/Source/Modules/delves_dash_extention/delves_dash_extention.xml
@@ -33,8 +33,8 @@
         hidden="true" inherits="DefaultPanelTemplate">
         <Size x="380" y="428" />
         <Anchors>
-            <Anchor point="TOPLEFT" relativeTo="$parent" relativePoint="TOPRIGHT" x="0" y="0" />
-            <Anchor point="BOTTOMLEFT" relativeTo="$parent" relativePoint="BOTTOMRIGHT" x="0" y="0" />
+            <Anchor point="TOPLEFT" relativeTo="$parent" relativePoint="TOPRIGHT" x="-4" y="0" />
+            <Anchor point="BOTTOMLEFT" relativeTo="$parent" relativePoint="BOTTOMRIGHT" x="-4" y="0" />
         </Anchors>
         <Layers>
             <Layer level="OVERLAY">

--- a/locale/enUS.lua
+++ b/locale/enUS.lua
@@ -32,6 +32,7 @@ lockit["ui-gilded-stash-cannot-retrieve-data"] = "Visit Khaz Algar zones to see 
 lockit["ui-gilded-stash-bountiful-note"] =
 "Appears only in |cnNORMAL_FONT_COLOR:Tier 11|r Bountiful Delves|A:delves-bountiful:16:16|a."
 lockit["ui-no-active-bountiful"] = "No active delves"
+lockit["ui-loot-info-button-tooltip-instruction"] = "<Click to display Delves' Loot info>"
 
 -- Loot Info
 lockit["ui-loot-info-description"] = "Complete a delve to get:"


### PR DESCRIPTION
- Display it by demand
- Put it above RIO tooltip