### PR TITLE
Save the in-delve widget's custom position

### DIFF
--- a/Data/Config.lua
+++ b/Data/Config.lua
@@ -21,6 +21,7 @@ Config.DELVES_MIN_EXPANSION = LE_EXPANSION_WAR_WITHIN
 ---@field inDelveWidgetEnabled boolean Whether [InDelveWidget](lua://InDelveWidget) is displayed.
 ---@field inDelveWidgetDisplayRule InDelveWidgetDisplayRule Where [InDelveWidget](lua://InDelveWidget) is displayed.
 ---@field inDelveWidgetLayout InDelveWidgetLayout How [InDelveWidget](lua://InDelveWidget) buttons are arranged.
+---@field inDelveWidgetPoint table|boolean Anchor of [InDelveWidget](lua://InDelveWidget) in custom mode, false until it is dragged.
 ---@field minimapIconEnabled boolean Whether a minimap icon is enabled.
 ---@field displayStoryStatusInGossip boolean Whether to display Story Variant status in Delves' Gossip.
 ---@field delveAutoEnterEnabled boolean Whether to enter Delves automatically once Gossip is shown.
@@ -33,6 +34,7 @@ Config.DEFAULT_ACCOUNT_DATA = {
     inDelveWidgetEnabled = true,
     inDelveWidgetDisplayRule = DelveCompanion.Definitions.InDelveWidgetDisplayRule.left,
     inDelveWidgetLayout = DelveCompanion.Definitions.InDelveWidgetLayout.vertical,
+    inDelveWidgetPoint = false,
     minimapIconEnabled = false,
     displayStoryStatusInGossip = true,
     delveAutoEnterEnabled = false,

--- a/Source/Modules/ProgressTracker/InDelveWidget/InDelveWidgetFrame.lua
+++ b/Source/Modules/ProgressTracker/InDelveWidget/InDelveWidgetFrame.lua
@@ -27,6 +27,22 @@ local SAVE_KEYS = {
 }
 --#endregion
 
+---@param self InDelveWidgetFrame
+local function EndDrag(self)
+    self:StopMovingOrSizing()
+    self.isMovingWidget = nil
+
+    -- dragging re-anchors the frame, so the anchor is saved with the offsets
+    local point, _, relativePoint, x, y = self:GetPoint()
+    DelveCompanionAccountData.inDelveWidgetPoint = {
+        point = point,
+        relativePoint = relativePoint,
+        x = x,
+        y = y,
+        scale = self:GetScale()
+    }
+end
+
 ---@class (exact) InDelveWidgetFrame : InDelveWidgetFrameXml
 ---@field isSet boolean
 ---@field delveExpansion number
@@ -44,6 +60,20 @@ function DelveCompanion_InDelveWidgetFrameMixin:Refresh()
 
     if DelveCompanionAccountData.inDelveWidgetDisplayRule == DelveCompanion.Definitions.InDelveWidgetDisplayRule.custom then
         self.DragCatcher:Show()
+
+        -- re-anchoring mid-drag would snap the widget back under the cursor
+        if not self.isMovingWidget then
+            local saved = DelveCompanionAccountData.inDelveWidgetPoint
+            self:ClearAllPoints()
+            if type(saved) == "table" then
+                -- offsets are in the frame's own scaled space, so divide out the saved scale
+                local factor = (saved.scale or 1) / self:GetScale()
+                self:SetPoint(saved.point, UIParent, saved.relativePoint,
+                    saved.x * factor, saved.y * factor)
+            else
+                self:SetPoint("TOPLEFT", ScenarioObjectiveTracker.Header, "BOTTOMRIGHT", 0, 0)
+            end
+        end
     else
         self.DragCatcher:Hide()
 
@@ -214,6 +244,7 @@ function DelveCompanion_InDelveWidgetFrameMixin:OnLoad()
                 return
             end
 
+            self.isMovingWidget = true
             self:StartMoving()
         end
 
@@ -222,7 +253,12 @@ function DelveCompanion_InDelveWidgetFrameMixin:OnLoad()
                 return
             end
 
-            self:StopMovingOrSizing()
+            -- a right-click that never started a drag here must not save an anchor
+            if not self.isMovingWidget then
+                return
+            end
+
+            EndDrag(self)
         end
 
         self.DragCatcher:SetScript("OnMouseDown", OnMouseDown)
@@ -251,6 +287,11 @@ end
 ---@param self InDelveWidgetFrame
 function DelveCompanion_InDelveWidgetFrameMixin:OnHide()
     -- Logger:Log("[InDelveWidgetFrame] OnHide start")
+
+    -- hiding ends the move without a mouse-up, so the drop is finished here
+    if self.isMovingWidget then
+        EndDrag(self)
+    end
 
     self:ResetWidget()
 


### PR DESCRIPTION
After moving the widget with Display Location set to Custom, relogging loses it
until the setting is changed to Left or Right.

OnMouseUp does not save the new anchor, while Refresh only anchors Left and Right
modes.
